### PR TITLE
기본적인 파티방 조회 화면 페이지 구현 및 API 적용 완료

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import PartyRoomCreation from "./components/partyRoom/partyRoomCreate/PartyRoomC
 import DeliverusList from './components/DeliverusList/DeliverusList';
 import RestaurantList from './components/partials/restaurantList/RestaurantList';
 import PersonalMenuSelecting from "./components/partyRoom/partyRoomEnter/PersonalMenuSelecting";
+import MyPartyRoom from "./components/partyRoom/mainPartyRoom/MyPartyRoom";
 
 function App() {
   const context = useContext(UserContext);
@@ -38,6 +39,7 @@ function App() {
           <Route path="/party/list" element={<DeliverusList />} />
           <Route path="/party/creation" element={<PartyRoomCreation />} />
           <Route path="/party/enter" element={<PersonalMenuSelecting />} />
+          <Route path="/party/myPartyRoom" element={<MyPartyRoom />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -7,7 +7,7 @@ import {
   ThemeProvider,
   createTheme,
 } from "@mui/material";
-import { useContext } from "react";
+import React, { useContext } from "react";
 import { Link } from "react-router-dom";
 import { UserContext } from "./store/UserContext";
 
@@ -77,7 +77,7 @@ const Header = () => {
                     방 만들기
                   </Link>
                   <Link
-                  to="/"
+                  to="/party/myPartyRoom"
                   style={{
                     textDecoration: "none",
                     background:"black",

--- a/src/components/mainContents/MainContents.js
+++ b/src/components/mainContents/MainContents.js
@@ -36,7 +36,7 @@ const MainContents = () => {
         setRecommendList(["양식", "일식", "중식", "한식", "치킨"]);
 
         // 처음 화면이 띄워졌을 때 모든 인접 파티방 리스트를 받아옵니다.
-        fetch(`${API.PARTY_LOCATION}`, {
+        fetch(`${API.PARTY_ALL}`, {
             method : "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/src/components/partyRoom/mainPartyRoom/MyPartyRoom.js
+++ b/src/components/partyRoom/mainPartyRoom/MyPartyRoom.js
@@ -1,0 +1,194 @@
+import {Box} from "@mui/material";
+import Typography from "@mui/material/Typography";
+import React, {Fragment, useContext, useEffect, useState} from "react";
+import KakaoMapStore from "../../restaurant/KakaoMapStore";
+import {API} from "../../../utils/config";
+import * as status from "../../../utils/status";
+import {UserContext} from "../../store/UserContext";
+import {useNavigate} from "react-router-dom";
+import Button from "@mui/material/Button";
+import CircularProgress from '@mui/material/CircularProgress';
+import LetterAvatar from "../../ui/LetterAvatar";
+
+// 두 개의 위도, 경도 사이의 거리를 미터 단위로 반환하는 함수
+function calculateDistance(lat1, lon1, lat2, lon2) {
+    const earthRadius = 6371e3; // 지구의 반지름 (미터 단위)
+    const toRadians = (value) => (value * Math.PI) / 180; // 각도를 라디안으로 변환
+
+    // 위도 및 경도를 라디안으로 변환
+    const radLat1 = toRadians(lat1);
+    const radLon1 = toRadians(lon1);
+    const radLat2 = toRadians(lat2);
+    const radLon2 = toRadians(lon2);
+
+    // 위도 및 경도의 차이 계산
+    const deltaLat = radLat2 - radLat1;
+    const deltaLon = radLon2 - radLon1;
+
+    // Haversine 공식 적용
+    const a =
+        Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+        Math.cos(radLat1) * Math.cos(radLat2) * Math.sin(deltaLon / 2) * Math.sin(deltaLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    // 거리 계산 (미터 단위)
+    const distance = earthRadius * c;
+
+    return Math.round(distance);
+}
+
+
+
+// 먼저 서버에게 사용자가 참여중인 파티방 id를 달라고 API 요청을 한다.
+// 파티방 id가 존재하면 그 id로 서버에게 파티방 정보를 달라고 합니다.
+function MyPartyRoom() {
+    const context = useContext(UserContext);
+    const {userState, handleLogOut} = context;
+    const {username, userPos} = userState;
+
+    const navigate = useNavigate();
+
+    // 내가 속해 있는 파티방 ID를 가지고 있는 변수
+    const [myPartyId, setMyPartyId] = useState(-1);
+
+    // 내가 속해 있는 파티방 정보를 가지고 있는 변수
+    const [myPartyInfo, setMyPartyInfo] = useState(null);
+
+    const handleExitPartyRoom = () => {
+        setMyPartyInfo(null);
+        fetch(`${API.PARTY_DELETE}/${username}`, {
+            method : "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            credentials: "include",
+        })
+            .then((respones) => {
+                status.handlePartyResponse(respones.status);
+                return respones.text();
+            })
+            .then((data) => {
+                console.log("Respones Data from PARTY DELETE API : ", data);
+                alert("딜리버스에서 나오셨습니다!");
+                navigate("/");
+            })
+            .catch((error) => {
+                // 로그인 만료 에러인 경우 로그아웃 실행
+                if (error.name === "LoginExpirationError") {
+                    handleLogOut();
+                }
+                console.log(`PARTY DELETE API -> ${error.name} : ${error.message}`);
+            });
+    }
+
+    // 맨 처음에 username을 가지고 사용자가 속해있는 파티방의 ID를 GET 합니다.
+    useEffect(() => {
+        fetch(`${API.PARTY_ID}?name=${username}`, {
+            headers: {
+                "Content-Type": "application/json",
+            },
+            credentials: "include",
+        })
+            .then((respones) => {
+                status.handlePartyResponse(respones.status);
+                return respones.text();
+            })
+            .then((data) => {
+                console.log("Respones Data from PARTY ID API : ", data);
+                // 사용자가 속해 있는 파티방이 있는 경우
+                if (Number(data) !== -1) {
+                    setMyPartyId(data);
+                }
+                // 사용자가 속해있는 파티방이 없는 경우 main화면으로 이동
+                else {
+                    navigate("/");
+                }
+            })
+            .catch((error) => {
+                // 로그인 만료 에러인 경우 로그아웃 실행
+                if (error.name === "LoginExpirationError") {
+                    handleLogOut();
+                }
+                console.log(`PARTY ID API -> ${error.name} : ${error.message}`);
+            });
+    }, []);
+
+
+    // 파티방 ID로 부터 파티방의 정보를 받아옵니다.
+    useEffect(() => {
+        if (myPartyId !== -1) {
+            fetch(`${API.PARTY}?id=${myPartyId}`, {
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                credentials: "include",
+            })
+                .then((respones) => {
+                    status.handlePartyResponse(respones.status);
+                    return respones.json();
+                })
+                .then((data) => {
+                    console.log("Respones Data from PARTY API : ", data);
+                    setMyPartyInfo(data);
+                })
+                .catch((error) => {
+                    // 로그인 만료 에러인 경우 로그아웃 실행
+                    if (error.name === "LoginExpirationError") {
+                        handleLogOut();
+                    }
+                    console.log(`GET PARTY API -> ${error.name} : ${error.message}`);
+                });
+        }
+    }, [myPartyId])
+
+    return (<Box component="main" sx={{
+        my: 8,
+        mx: 'auto',
+        px: 4,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        maxWidth: 'md'
+    }}>
+        {myPartyInfo ? (<Fragment>
+            <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                파티방 이름 : {myPartyInfo.partyName}
+            </Typography>
+            <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                호스트 : {myPartyInfo.host}
+            </Typography>
+            <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                위치 : {myPartyInfo.pickUpAddress.split("|")[0]}
+            </Typography>
+            <Box sx={{width: "100%", height: "500px"}}>
+                <KakaoMapStore
+                    lat={myPartyInfo.latitude}
+                    lng={myPartyInfo.longitude}
+                />
+            </Box>
+            <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                거리 : {calculateDistance(userPos.lat, userPos.lng, myPartyInfo.latitude, myPartyInfo.longitude)}m
+            </Typography>
+            <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                픽업 상세 위치 : {myPartyInfo.pickUpAddress.split("|")[1]}
+            </Typography>
+            <Box sx={{display: "flex"}}>
+                <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
+                    참가자 정보 :
+                </Typography>
+                {myPartyInfo.partyMembers.map((item, index) => {
+                    return (
+                        <LetterAvatar key={index} name={item.nickname} />
+                    );
+                })}
+            </Box>
+            <Button
+                fullWidth
+                variant="contained"
+                onClick={handleExitPartyRoom}
+                sx={{mt: 3, mb: 2}}
+            >딜리버스 나가기</Button> </Fragment>) : (<CircularProgress/>)}
+    </Box>);
+}
+
+export default MyPartyRoom;

--- a/src/components/partyRoom/partyRoomCreate/PartyPositionSetting.js
+++ b/src/components/partyRoom/partyRoomCreate/PartyPositionSetting.js
@@ -19,7 +19,7 @@ function PartyPositionSetting(props) {
     const [detailPos, setDetailPos] = useState("");
 
     // 원의 반경, 단위는 m
-    const radius = 500;
+    const radius = 3000;
 
     // 사용자가 위치를 설정했냐 확인하는 변수
     const [state, setState] = useState(false);

--- a/src/components/partyRoom/partyRoomCreate/PartyRoomCreateResult.js
+++ b/src/components/partyRoom/partyRoomCreate/PartyRoomCreateResult.js
@@ -6,6 +6,7 @@ import Grid from "@mui/material/Grid";
 import MenuCard from "../../restaurant/MenuCard";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import {Box} from "@mui/material";
 
 // 파티방을 만들 때 설정 사항들을 최종적으로 보여주는 컴퍼넌트입니다.
 function PartyRoomCrateResult(props) {
@@ -24,10 +25,12 @@ function PartyRoomCrateResult(props) {
             <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
                 도로명 주소 : {props.partyInfo.pickUpAddress}
             </Typography>
-            <KakaoMapStore
-                lat={props.partyInfo.latitude}
-                lng={props.partyInfo.longitude}
-            />
+            <Box sx={{width :"55vh", height: "55vh"}}>
+                <KakaoMapStore
+                    lat={props.partyInfo.latitude}
+                    lng={props.partyInfo.longitude}
+                />
+            </Box>
             <Typography component="h1" variant="h6" sx={{margin: "auto"}}>
                 상세 주소 : {props.detailPos}
             </Typography>

--- a/src/components/partyRoom/partyRoomCreate/PartyRoomCreation.js
+++ b/src/components/partyRoom/partyRoomCreate/PartyRoomCreation.js
@@ -80,7 +80,7 @@ function PartyRoomCreation() {
     };
 
     const handleSubmit = () => {
-        alert("모든 작업 끝!");
+        alert("파티방 생성!");
         const finalPartyInfo = {...partyInfo};
         finalPartyInfo.host = username;
         // pickUpAddress 프러퍼티에서 '|' 문자을 이용해 픽업장소의 도로명 주소와 상세 설명을 나눕니다.

--- a/src/components/partyRoom/partyRoomEnter/PersonalMenuSelecting.js
+++ b/src/components/partyRoom/partyRoomEnter/PersonalMenuSelecting.js
@@ -20,8 +20,6 @@ function PersonalMenuSelecting() {
     const restaurantId = location.state.resId;
     const partyId = location.state.partyId;
 
-    console.log("party id : ", partyId);
-
     // 서버로부터 가게 정보를 받을 변수
     const [restaurant, setRestaurant] = useState({
         menu: {
@@ -37,7 +35,6 @@ function PersonalMenuSelecting() {
 
     // 각 메뉴에 대한 수량을 담은 리스트
     const [countList, setCountList] = useState([0]);
-
 
     // 가게의 ID를 가지고 서버로부터 가게 정보 받기
     useEffect(() => {
@@ -73,8 +70,6 @@ function PersonalMenuSelecting() {
     }, []);
 
     const handleNext = () => {
-        alert("파티방 화면으로 이동!");
-
         // 사용자가 선택한 메뉴에 대한 정보 담기
         const orderList = [];
         restaurant.menu.menu.map((item, index) => {
@@ -116,6 +111,8 @@ function PersonalMenuSelecting() {
                     handleLogOut();
                 }
                 console.log(`${error.name} : ${error.message}`);
+                // 마지막으로 메인 화면으로 이동
+                navigate("/");
             });
     };
 

--- a/src/components/restaurant/KakaoMapStore.jsx
+++ b/src/components/restaurant/KakaoMapStore.jsx
@@ -19,8 +19,8 @@ export default function KakaoMapStore({ lat, lng }) {
         
     return (
     <div id='map' style={{
-        width: '582px',
-        height: '270px'
+        width: '100%',
+        height: "100%"
     }}></div>
     );
 }

--- a/src/components/restaurant/RecruitingPartyCard.js
+++ b/src/components/restaurant/RecruitingPartyCard.js
@@ -8,15 +8,22 @@ import AccountCircle from "@mui/icons-material/AccountCircle";
 import Typography from "@mui/material/Typography";
 import CardActions from "@mui/material/CardActions";
 import Button from "@mui/material/Button";
+import {useContext} from "react";
+import {UserContext} from "../store/UserContext";
+import LetterAvatar from "../ui/LetterAvatar";
 
 // 모듈화를 진행한 컴포넌트입니다.
 // 하나의 파티방의 정보를 담은 컴포넌트입니다,
 function RecruitingPartyCard(props) {
+    const context = useContext(UserContext);
+    const {userState} = context;
+    const {username} = userState;
+
     const recruitPartyInfo = props.partyInfo;
     return (
         <Card variant="outlined" sx={{display: "flex", p: 1.5}}>
             <CardContent sx={{my: "auto", px: 0, pl: 1}}>
-                <AccountCircle />
+                <LetterAvatar name={username}/>
             </CardContent>
             <Box sx={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between', width: 1}}>
                 <CardContent sx={{ml: 3}}>
@@ -32,7 +39,7 @@ function RecruitingPartyCard(props) {
                         {recruitPartyInfo.currentMemberNum}/{recruitPartyInfo.memberNum}
                     </Typography>
                     <Typography variant="body2" style={{fontSize: "16px"}}>
-                        {recruitPartyInfo.distance}
+                        {Math.round(recruitPartyInfo.distance)}m
                     </Typography>
                     <Button size="small" onClick={(e) => {props.propFunction(recruitPartyInfo, e)}} style={{fontSize: "16px"}}>
                         참여하기</Button>

--- a/src/components/restaurant/RecruitingPartyList.js
+++ b/src/components/restaurant/RecruitingPartyList.js
@@ -2,7 +2,7 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import React, {useState} from "react";
 import Dialog from "@mui/material/Dialog";
-import {DialogActions, DialogContent, DialogTitle} from "@mui/material";
+import {Box, DialogActions, DialogContent, DialogTitle} from "@mui/material";
 import Image from "mui-image";
 import KakaoMapStore from './KakaoMapStore';
 import Stack from "@mui/material/Stack";
@@ -17,7 +17,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 
 // 해당 가게 주문을 위해 모집 중인 파티방을 보여주는 컴포넌트입니다.
 // prop으로 파티방 정보 리스트, 메뉴 리스트를 받습니다.
-    const RecruitingPartyList = (props) => {
+const RecruitingPartyList = (props) => {
     const navigate = useNavigate();
 
     // 파티방 정보 리스트
@@ -49,8 +49,8 @@ const Transition = React.forwardRef(function Transition(props, ref) {
     const handleEnterMenuSelecting = () => {
         navigate("/party/enter", {
             state: {
-                resId : restaurantId,
-                partyId : partyInfo.partyId
+                resId: restaurantId,
+                partyId: partyInfo.partyId
             }
         })
         setOpen(false);
@@ -61,7 +61,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
         category: "",
         latitude: 0,
         longitude: 0,
-        restaurantName : "",
+        restaurantName: "",
         restaurantId: 0
     });
 
@@ -69,11 +69,11 @@ const Transition = React.forwardRef(function Transition(props, ref) {
 
     return (
         <Stack spacing={3}>
-        {recruitingPartyList.map((item, idx) => {
-        return (
-                <RecruitingPartyCard key={idx} propFunction={handleClickOpen} partyInfo={item}/>
-        );
-        })}
+            {recruitingPartyList.map((item, idx) => {
+                return (
+                    <RecruitingPartyCard key={idx} propFunction={handleClickOpen} partyInfo={item}/>
+                );
+            })}
             <Dialog open={open}
                     onClose={handleClose}
                     TransitionComponent={Transition}
@@ -81,7 +81,7 @@ const Transition = React.forwardRef(function Transition(props, ref) {
                     fullWidth={true}
                     maxWidth="sm">
                 <DialogTitle>가게 정보 확인</DialogTitle>
-                <DialogContent sx={{border: 1, borderRadius: '16px', mx:1}}>
+                <DialogContent sx={{border: 1, borderRadius: '16px', mx: 1}}>
                     <Image src={image}
                            height="150px"
                            widht="150px"
@@ -91,13 +91,15 @@ const Transition = React.forwardRef(function Transition(props, ref) {
                     <Typography align="center" component="h5" variant="h5">
                         {partyInfo.partyName}
                     </Typography>
-                </DialogContent >
+                </DialogContent>
                 <DialogTitle>픽업 위치 확인</DialogTitle>
-                <DialogContent sx={{border: 1, borderRadius: '16px', mx:1}}>
-                    <KakaoMapStore 
-                    lat={partyInfo.latitude}
-                    lng={partyInfo.longitude}
-                    />
+                <DialogContent sx={{border: 1, borderRadius: '16px', mx: 1, p:0}}>
+                    <Box sx={{width :"100%", height: "500px"}}>
+                        <KakaoMapStore
+                            lat={partyInfo.latitude}
+                            lng={partyInfo.longitude}
+                        />
+                    </Box>
                 </DialogContent>
                 <DialogActions>
                     <Button onClick={handleEnterMenuSelecting}>딜리버스 참가하기</Button>

--- a/src/components/ui/LetterAvatar.js
+++ b/src/components/ui/LetterAvatar.js
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import Avatar from '@mui/material/Avatar';
+
+function stringToColor(string) {
+    let hash = 0;
+    let i;
+
+    /* eslint-disable no-bitwise */
+    for (i = 0; i < string.length; i += 1) {
+        hash = string.charCodeAt(i) + ((hash << 5) - hash);
+    }
+
+    let color = '#';
+
+    for (i = 0; i < 3; i += 1) {
+        const value = (hash >> (i * 8)) & 0xff;
+        color += `00${value.toString(16)}`.slice(-2);
+    }
+    /* eslint-enable no-bitwise */
+
+    return color;
+}
+
+function stringAvatar(name) {
+    let defaultChild = "U"
+    if(name) {
+        defaultChild = name.substring(0, 1);
+    }
+    return {
+        sx: {
+            bgcolor: stringToColor(name),
+        },
+        children: defaultChild,
+    };
+}
+
+// props로 이름이 들어옵니다.
+// 이름을 가지고 Avatar를 만들어줍니다.
+export default function LetterAvatar(props) {
+    return (
+            <Avatar {...stringAvatar(props.name)} />
+    );
+}

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -9,8 +9,10 @@ export const API = {
     RESTAURANT_LIST: `${BASE_URL}/api/restaurant/list`,
     RESTAURANT_INFORMATION: `${BASE_URL}/api/restaurant/info`,
     RESTAURANT_ALL: `${BASE_URL}/api/restaurant/all`,
-    PARTY: `${BASE_URL}/api/party`, // 파티방 생성 API
-    PARTY_LOCATION: `${BASE_URL}/api/party/location`, // 내 위치 주변에 생성된 파티방 가져오는 API
-    PARTY_VALIDATION: `${BASE_URL}/api/party/validation`,
+    PARTY: `${BASE_URL}/api/party`, // POST : 파티방 생성 API, GET : 파티방 정보 조회 API
+    PARTY_ALL: `${BASE_URL}/api/party/all`, // 내 위치 주변에 생성된 파티방 가져오는 API
+    PARTY_ID: `${BASE_URL}/api/party/id`,
     PARTY_MEMBER : `${BASE_URL}/api/party/member`,
+    PARTY_DELETE : `${BASE_URL}/api/party/member`,
+    PARTY_RESTAURANT : `${BASE_URL}/api/party/restaurant`,
 }


### PR DESCRIPTION
- 카테고리 filter 기능 Merge 완료
- 가게 정보 화면에서 현재 모집 중인 파티방 정보를 서버에서부터 받아옵니다.
- 파티방 조회 화면 페이지를 간단하게 구현했습니다. 일단은 Navbar의 마이페이지 버튼을 통해 이동할 수 있습니다.
